### PR TITLE
added clean option for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install --save ps-man
 - list
   * name : Process name - _optional_
   * pid : Process identifier - _optional_
+  * clean : boolean to return clean list for mac - _optional_
 - kill
   * pidList : Array of process identifier - _mandatory_
   * signal : The  default signal for kill is TERM. (see ``man ps``) - _optional - OSX/Linux only_
@@ -40,6 +41,21 @@ var ps = require('ps-man');
 // Filter by pid
 var options = {
   pid: 1501
+};
+
+ps.list(options, function(err, result) {
+  // my stuff here
+});
+```
+
+#### Return a cleaned list for mac
+
+```javascript
+var ps = require('ps-man');
+
+// Filter by pid
+var options = {
+  clean: true
 };
 
 ps.list(options, function(err, result) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,10 +21,10 @@ var operations   = {
 
 if (/win32/.test(platform)) {
   operations.ps.command   = 'tasklist',
-  operations.ps.arguments = ['/v', '/FO', 'CSV']
+      operations.ps.arguments = ['/v', '/FO', 'CSV']
 
   operations.kill.command   = 'taskkill',
-  operations.kill.arguments = []
+      operations.kill.arguments = []
 
   operations.ps.indexes.pid     = 1;
   operations.ps.indexes.command = 0;
@@ -32,6 +32,9 @@ if (/win32/.test(platform)) {
 
 var listProcesses = function(options, done) {
   // Prevent errors
+  if(options.clean && !/win32/.test(platform)) {
+    operations.ps.arguments =  ['axco','pid,command'];
+  }
   if (done == null){
     done    = options;
     options = {};


### PR DESCRIPTION
mac command returns folder structure and that is not always desired. The current project I am using this for I need clear names that are the same regardless of where the application was installed. I added a 'clean' option to the options object that returns a clean list. It will not change anything for people currently using the application and gives the ability to returned the non foldered list.
