### PR TITLE
Allow options.name to take RegExp object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,14 @@ var listProcesses = function(options, done) {
       });
 
       if (options.name != null) {
-        var name = new RegExp(options.name);
+        var optionsName = options.name;
+        var name;
+
+        if (options.name instanceof RegExp) {
+          name = options.name;
+        } else {
+          name = new RegExp(options.name);
+        }
 
         processList = processList.filter(function(item) {
           return name.test(item.command);


### PR DESCRIPTION
This allows users to do things like case insensitive searches via:

```
// Filter by name
var options = {
  name: new RegExp('dropbox', 'i')
};
```