### PR TITLE
Fix Windows error about pushing multiple /T arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,11 +130,10 @@ var killProcesses = function(options, done) {
   var killArguments = operations.kill.arguments.concat(signals, pidList)
 
   if (/win32/.test(platform)) {
-    killArguments = ['/F'];
+    killArguments = ['/F', '/T'];
     pidList.forEach(function(pid) {
       killArguments.push('/PID');
       killArguments.push(pid);
-      killArguments.push('/t');
     });
   }
 


### PR DESCRIPTION
On Windows, `/T` is the flag for `taskkill` with a definition of
> Terminates the specified process and any child processes which were started by it.  

It is only allowed once and for some reason you told someone with this problem to use VSCode to debug the error? (https://github.com/xsellier/node-ps/issues/3#issuecomment-284265234) This fixes the `/T` argument error. 